### PR TITLE
Throw exception on curl exec error

### DIFF
--- a/Loggly.php
+++ b/Loggly.php
@@ -76,10 +76,13 @@ class Loggly {
         }
 
         $result = curl_exec($curl);
-        $status = curl_getinfo($curl, CURLINFO_HTTP_CODE); 
+
+        if (!$result) {
+          throw new LogglyException(curl_error($curl));
+        }
 
         $json = json_decode($result, true);
-        if (!$json && $result) {
+        if (!$json) {
             # API is inconsistent
             $status = curl_getinfo($curl, CURLINFO_HTTP_CODE); 
             if ($status >= 200 && $status <= 299) {


### PR DESCRIPTION
Currently curl_exec errors are not handled. This causes curl error (such as connection error, invalid SSL certificate, etc.) to return null $json (hits line 93).

This patch checks curl_exec return value and throw on error.

Also removed unnecessary double initialization of $status.
